### PR TITLE
Update wp-accessibility.php

### DIFF
--- a/wp-accessibility.php
+++ b/wp-accessibility.php
@@ -668,7 +668,7 @@ if ( get_option( 'wpa_search' ) == 'on' ) {
 
 function wpa_filter( $query ) {
 	if ( ! is_admin() ) {
-		if ( isset( $_GET['s'] ) && $_GET['s'] == '' && $query->is_main_query() ) {
+		if ( isset( $_GET['s'] ) && ( trim($_GET['s'] ) == NULL ) && ( $query->is_main_query() ) ) {
 			$query->query_vars['s'] = '&#32;';
 			$query->set( 'is_search', 1 );
 			add_action( 'template_include', 'wpa_search_error' );

--- a/wp-accessibility.php
+++ b/wp-accessibility.php
@@ -668,7 +668,7 @@ if ( get_option( 'wpa_search' ) == 'on' ) {
 
 function wpa_filter( $query ) {
 	if ( ! is_admin() ) {
-		if ( isset( $_GET['s'] ) && $_GET['s'] == '' ) {
+		if ( isset( $_GET['s'] ) && $_GET['s'] == '' && $query->is_main_query() ) {
 			$query->query_vars['s'] = '&#32;';
 			$query->set( 'is_search', 1 );
 			add_action( 'template_include', 'wpa_search_error' );


### PR DESCRIPTION
Adding a test for is_main_query prevents the navigation menu from vanishing on empty searches as explained by @GaryJones 

"WPA filters the query to add in a space for `s`

However, that filter also kicks in when WP does a completely un-related query to get the nav menu items (they are posts too remember). Since s=' ' & post_type= nav_menu_item results in no results returned from the query, (presumably because the search query probably limits it to certain post types, and the nav query wants it to be a different post type, it can't be A and B at the same time), then the nav menu fails to show up."