### PR TITLE
A few enhancements for screen reader users

### DIFF
--- a/toolbar/js/a11y.js
+++ b/toolbar/js/a11y.js
@@ -45,7 +45,7 @@ jQuery(document).ready(function ($) {
             return false;
         } else {
             $('body').removeClass('desaturated');
-            $(this).attr('id', 'is_normal_color').removeAttr('aria-pressed').removeClass('active');
+            $(this).attr('id', 'is_normal_color').attr('aria-pressed', false).removeClass('active');
             eraseCookie('a11y-desaturated');
             return false;
         }
@@ -71,7 +71,7 @@ jQuery(document).ready(function ($) {
         } else {
             $('#highContrastStylesheet').remove();
             $('body').removeClass('contrast');
-            $(this).attr('id', 'is_normal_contrast').removeAttr('aria-pressed').removeClass('active');
+            $(this).attr('id', 'is_normal_contrast').attr('aria-pressed', false).removeClass('active');
             $(this).parent().parent().find('i').removeClass('icon-white');
             eraseCookie('a11y-high-contrast');
             return false;
@@ -81,18 +81,18 @@ jQuery(document).ready(function ($) {
     // Fontsize handler
     if (readCookie('a11y-larger-fontsize')) {
         $('html').addClass('fontsize');
-        $('#is_normal_fontsize').attr('id', 'is_large_fontsize').attr('aria-checked', true).addClass('active');
+        $('#is_normal_fontsize').attr('id', 'is_large_fontsize').attr('aria-pressed', true).addClass('active');
     }
 
     $('.toggle-fontsize').on('click', function () {
         if ($(this).attr('id') == "is_normal_fontsize") {
             $('html').addClass('fontsize');
-            $(this).attr('id', 'is_large_fontsize').attr('aria-checked', true).addClass('active');
+            $(this).attr('id', 'is_large_fontsize').attr('aria-pressed', true).addClass('active');
             createCookie('a11y-larger-fontsize', '1');
             return false;
         } else {
             $('html').removeClass('fontsize');
-            $(this).attr('id', 'is_normal_fontsize').removeAttr('aria-checked').removeClass('active');
+            $(this).attr('id', 'is_normal_fontsize').attr('aria-pressed', false).removeClass('active');
             eraseCookie('a11y-larger-fontsize');
             return false;
         }

--- a/wp-accessibility.php
+++ b/wp-accessibility.php
@@ -275,12 +275,12 @@ function wpa_toolbar_js() {
 	var insert_a11y_toolbar = '<!-- a11y toolbar -->';
 	insert_a11y_toolbar += '<div class=\"$responsive a11y-toolbar$is_rtl$is_right\">';
 	insert_a11y_toolbar += '<ul class=\"a11y-toolbar-list\">';
-	insert_a11y_toolbar += '<li class=\"a11y-toolbar-list-item\"><button type=\"button\" class=\"a11y-toggle-contrast toggle-contrast\" id=\"is_normal_contrast\"><span class=\"offscreen\">$contrast</span><span class=\"aticon aticon-adjust\" aria-hidden=\"true\"></span></button></li>';";
+	insert_a11y_toolbar += '<li class=\"a11y-toolbar-list-item\"><button type=\"button\" class=\"a11y-toggle-contrast toggle-contrast\" id=\"is_normal_contrast\" aria-pressed=\"false\"><span class=\"offscreen\">$contrast</span><span class=\"aticon aticon-adjust\" aria-hidden=\"true\"></span></button></li>';";
 	if ( get_option( 'wpa_toolbar' ) == 'on' && $enable_grayscale ) {
-		echo "insert_a11y_toolbar += '<li class=\"a11y-toolbar-list-item\"><button type=\"button\" class=\"a11y-toggle-grayscale toggle-grayscale\" id=\"is_normal_color\"><span class=\"offscreen\">$grayscale</span><span class=\"aticon aticon-tint\" aria-hidden=\"true\"></span></button></li>';";
+		echo "insert_a11y_toolbar += '<li class=\"a11y-toolbar-list-item\"><button type=\"button\" class=\"a11y-toggle-grayscale toggle-grayscale\" id=\"is_normal_color\" aria-pressed=\"false\"><span class=\"offscreen\">$grayscale</span><span class=\"aticon aticon-tint\" aria-hidden=\"true\"></span></button></li>';";
 	}
 	echo "
-	insert_a11y_toolbar += '<li class=\"a11y-toolbar-list-item\"><button type=\"button\" class=\"a11y-toggle-fontsize toggle-fontsize\" id=\"is_normal_fontsize\"><span class=\"offscreen\">$fontsize</span><span class=\"aticon aticon-font\" aria-hidden=\"true\"></span></button></li>';
+	insert_a11y_toolbar += '<li class=\"a11y-toolbar-list-item\"><button type=\"button\" class=\"a11y-toggle-fontsize toggle-fontsize\" id=\"is_normal_fontsize\" aria-pressed=\"false\"><span class=\"offscreen\">$fontsize</span><span class=\"aticon aticon-font\" aria-hidden=\"true\"></span></button></li>';
 	insert_a11y_toolbar += '</ul>';
 	insert_a11y_toolbar += '</div>';
 	insert_a11y_toolbar += '<!-- // a11y toolbar -->';


### PR DESCRIPTION
Now the aria-pressed attribute is set to false in all toolbar items instead of removing it. Also, I have changed aria-checked to aria-pressed in the change fontsize button, and set the aria-pressed to false by default in the php file. This will enhance user experience for screen reader users. They will always be able to know the state of the buttons.